### PR TITLE
Update mirror hostname from drive.labhub.eu.org to legacy.labhub.eu.org

### DIFF
--- a/scripts/dynamips/index.py
+++ b/scripts/dynamips/index.py
@@ -15,7 +15,7 @@ download_path = "/opt/unetlab/addons/dynamips/"
 image_type = "dynamips"
 hostnames = {
     "main": "labhub.eu.org",
-    "drive": "drive.labhub.eu.org"
+    "drive": "legacy.labhub.eu.org"
 }
 prefixes = {
     "main": "/api/raw/?path=",

--- a/scripts/iol/index.py
+++ b/scripts/iol/index.py
@@ -15,7 +15,7 @@ download_path = "/opt/unetlab/addons/iol/bin/"
 image_type = "iol"  # Hardcoded for IOL
 hostnames = {
     "main": "labhub.eu.org",
-    "drive": "drive.labhub.eu.org"
+    "drive": "legacy.labhub.eu.org"
 }
 prefixes = {
     "main": "/api/raw/?path=",

--- a/scripts/qemu/index.py
+++ b/scripts/qemu/index.py
@@ -214,7 +214,7 @@ def generate_full_schema(index_data):
             "protocol": "https",
             "hostnames": {
                 "main": "labhub.eu.org",
-                "drive": "drive.labhub.eu.org"
+                "drive": "legacy.labhub.eu.org"
             },
             "prefixes": {
                 "main": "/api/raw/?path=",


### PR DESCRIPTION
- Changed drive mirror hostname in all three index scripts
- Updates QEMU, IOL, and Dynamips mirror configurations
- Fixes download issues with legacy LabHub mirror